### PR TITLE
IPC for `proxy:create` event

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -1,0 +1,13 @@
+import { IProxy } from "@/types";
+
+export interface IElectronAPI {
+  proxyCreate: (
+    proxy: Omit<IProxy, "id" | "state">,
+  ) => Promise<Omit<IProxy, "id" | "state">>;
+}
+
+declare global {
+  interface Window {
+    electronAPI: IElectronAPI;
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,2 +1,7 @@
-// See the Electron documentation for details on how to use preload scripts:
-// https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+import { contextBridge, ipcRenderer } from "electron";
+import { IProxy } from "@/types";
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  proxyCreate: (proxy: Omit<IProxy, "id" | "state">) =>
+    ipcRenderer.invoke("proxy:create", proxy),
+});

--- a/src/renderer/components/templates/CreateProxy/CreateProxy.tsx
+++ b/src/renderer/components/templates/CreateProxy/CreateProxy.tsx
@@ -69,7 +69,16 @@ const CreateProxy = () => {
     );
     proxyCreateClearErrors("proxyCreateError");
     try {
-      // proxyCreate.({ name, description, host, ports, username, password });
+      const proxy = {
+        name: name,
+        description: description,
+        port: port as number,
+        proxy_host: proxy_host,
+        proxy_port: proxy_port as number,
+        authentication: authentication,
+      };
+      const response = await window.electronAPI.proxyCreate(proxy);
+      console.log(response);
       proxyCreateReset();
     } catch (e) {
       proxyCreateSetError("proxyCreateError", {
@@ -78,8 +87,6 @@ const CreateProxy = () => {
       });
     }
   };
-
-  console.log(proxyCreateErrors);
 
   return (
     <DialogContent className="max-w-[604px]">

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -9,9 +9,11 @@ export interface IProxy {
   proxy_host: string;
   proxy_port: number;
   // TODO: type guard for authentication
-  authentication?: boolean;
-  proxy_username?: string;
-  proxy_password?: string;
+  authentication: {
+    authentication?: boolean;
+    proxy_username?: string;
+    proxy_password?: string;
+  };
 }
 
 import { z } from "zod";


### PR DESCRIPTION
* Add TypeScript for context isolation (interface.d.ts);
* Add IPC for `proxy:create` event (src/main.ts, src/preload.ts, src/renderer/components/templates/CreateProxy/CreateProxy.tsx);
* Update `IProxy` interface (src/types/proxy.ts).