### PR TITLE
Create `Layout`, Use XState for `CreateProxy`

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,60 +1,13 @@
-// import { proxyActor, proxyMachine } from "@/xstate";
-import { uiMachine } from "@/xstate";
-import { useMachine } from "@xstate/react";
-
-import { Header } from "@/renderer/components/common";
-import { Main } from "@/renderer/components/views";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { uiActor } from "@/xstate";
+import Layout from "@/renderer/components/layout";
 
 const App = () => {
-  // proxyActor.subscribe((snapshot) => {
-  //   console.log("Value:", snapshot.value);
-  // });
-  // proxyActor.start();
-  // proxyActor.send({ type: "activate" });
-
-  // TODO: add createActorContext
-  const [uiState, uiSend] = useMachine(uiMachine);
-
-  const [createProxyDialogOpen, setCreateProxyDialogOpen] =
-    useState<boolean>(false);
-
-  const [editProxyDialogOpen, setEditProxyDialogOpen] =
-    useState<boolean>(false);
-
-  const [selectedForEditProxy, setSelectedForEditProxy] = useState<
-    string | null
-  >(null);
-
   useEffect(() => {
-    if (selectedForEditProxy !== null) {
-      setEditProxyDialogOpen(true);
-    }
-  }, [selectedForEditProxy]);
+    uiActor.start();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!editProxyDialogOpen) {
-      setSelectedForEditProxy(null);
-    }
-  }, [editProxyDialogOpen]);
-
-  return (
-    <div className="container py-5 flex flex-col gap-6">
-      <div className="p-4 bg-slate-500 rounded-sm">
-        {uiState.value.toString()}
-      </div>
-      <Header
-        createProxyDialogOpen={createProxyDialogOpen}
-        setCreateProxyDialogOpen={setCreateProxyDialogOpen}
-        editProxyDialogOpen={editProxyDialogOpen}
-        setEditProxyDialogOpen={setEditProxyDialogOpen}
-        selectedForEditProxy={selectedForEditProxy}
-        uiState={uiState}
-        uiSend={uiSend}
-      />
-      <Main setSelectedForEditProxy={setSelectedForEditProxy} />
-    </div>
-  );
+  return <Layout />;
 };
 
 export default App;

--- a/src/renderer/components/common/Header/Header.tsx
+++ b/src/renderer/components/common/Header/Header.tsx
@@ -1,44 +1,37 @@
-import { CreateProxy, EditProxy } from "@/renderer/components/dialogs";
-import { Button, Dialog, DialogTrigger } from "@/renderer/components/ui/";
+import { uiActor } from "@/xstate";
+import { useSelector } from "@xstate/react";
 import { FC, SetStateAction, Dispatch } from "react";
-import { uiMachine } from "@/xstate";
-import { Actor, StateFrom } from "xstate";
+import { Button, Dialog } from "@/renderer/components/ui/";
+import { CreateProxy, EditProxy } from "@/renderer/components/dialogs";
 
 interface IHeaderProps {
-  createProxyDialogOpen: boolean;
-  setCreateProxyDialogOpen: Dispatch<SetStateAction<boolean>>;
   editProxyDialogOpen: boolean;
   setEditProxyDialogOpen: Dispatch<SetStateAction<boolean>>;
   selectedForEditProxy: string | null;
-  uiSend: Actor<typeof uiMachine>["send"];
-  uiState: StateFrom<typeof uiMachine>;
 }
 
 const Header: FC<IHeaderProps> = ({
-  createProxyDialogOpen,
-  setCreateProxyDialogOpen,
   editProxyDialogOpen,
   setEditProxyDialogOpen,
   selectedForEditProxy,
-  uiSend,
 }) => {
+  const state = useSelector(uiActor, (state) => state);
+  console.log(state);
+
+  console.log("state.matches('create')", state.matches("create"));
+
   return (
     <header className="flex justify-end">
-      <Dialog
-        open={createProxyDialogOpen}
-        onOpenChange={setCreateProxyDialogOpen}
-      >
-        <DialogTrigger asChild>
-          <Button
-            onClick={() => {
-              uiSend({ type: "create" });
-            }}
-            variant="outline"
-          >
-            Create Proxy
-          </Button>
-        </DialogTrigger>
-        <CreateProxy setOpen={setCreateProxyDialogOpen} />
+      <Dialog open={state.matches("create")}>
+        <Button
+          onClick={() => {
+            uiActor.send({ type: "create" });
+          }}
+          variant="outline"
+        >
+          Create Proxy
+        </Button>
+        <CreateProxy />
       </Dialog>
       <Dialog open={editProxyDialogOpen} onOpenChange={setEditProxyDialogOpen}>
         <EditProxy

--- a/src/renderer/components/layout/Layout.tsx
+++ b/src/renderer/components/layout/Layout.tsx
@@ -1,0 +1,46 @@
+import { Header } from "@/renderer/components/common";
+import { Main } from "@/renderer/components/views";
+import { useEffect, useState } from "react";
+import { uiActor } from "@/xstate";
+import { useSelector } from "@xstate/react";
+
+// TODO: listen to ESC button
+
+const Layout = () => {
+  const state = useSelector(uiActor, (state) => state);
+
+  const [editProxyDialogOpen, setEditProxyDialogOpen] =
+    useState<boolean>(false);
+
+  const [selectedForEditProxy, setSelectedForEditProxy] = useState<
+    string | null
+  >(null);
+
+  useEffect(() => {
+    if (selectedForEditProxy !== null) {
+      setEditProxyDialogOpen(true);
+    }
+  }, [selectedForEditProxy]);
+
+  useEffect(() => {
+    if (!editProxyDialogOpen) {
+      setSelectedForEditProxy(null);
+    }
+  }, [editProxyDialogOpen]);
+
+  return (
+    <div className="container py-5 flex flex-col gap-6">
+      <div className="p-4 bg-slate-500 rounded-sm">
+        {state.value.toString()}
+      </div>
+      <Header
+        editProxyDialogOpen={editProxyDialogOpen}
+        setEditProxyDialogOpen={setEditProxyDialogOpen}
+        selectedForEditProxy={selectedForEditProxy}
+      />
+      <Main setSelectedForEditProxy={setSelectedForEditProxy} />
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/renderer/components/layout/index.ts
+++ b/src/renderer/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Layout";

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -10,7 +10,23 @@ const DialogTrigger = DialogPrimitive.Trigger;
 
 const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close;
+const DialogClose = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Close
+    ref={ref}
+    className={cn(
+      "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  >
+    <X className="h-4 w-4" />
+    <span className="sr-only">Close</span>
+  </DialogPrimitive.Close>
+));
+DialogClose.displayName = DialogPrimitive.Close.displayName;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -20,7 +36,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className,
+      className
     )}
     {...props}
   />
@@ -37,15 +53,11 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className,
+        className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));
@@ -58,7 +70,7 @@ const DialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
-      className,
+      className
     )}
     {...props}
   />
@@ -72,7 +84,7 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className,
+      className
     )}
     {...props}
   />
@@ -87,7 +99,7 @@ const DialogTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
-      className,
+      className
     )}
     {...props}
   />

--- a/src/xstate/ui.ts
+++ b/src/xstate/ui.ts
@@ -1,4 +1,5 @@
 import { createMachine, createActor } from "xstate";
+
 const uiMachine = createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QFcCWA6VEA2YDEEYuALmANoAMAuoqAA4D2sqxqDAdrSAB6IC0AZgAsATnQAmCgICM4gKwAaEAE9E4oQDZ0AgOzSKOgByjZ+kUIC+FpWkw58AYwBOYAIalKNJCEbNWHLl4EQVF0OXFhXUUVRFkKdE0hYyirGwwsXDxIFk8uXxY2Tm8gjSEw6Wk9Qx1o1QRpDXF0HRENarlUkFts4jxsVFhiXO98-yLQIL4k9FakoSilOukxOQppAQpJQwEd3c7bQhJ8fsHh+iYCgOL+SQF0CoFxQ1laxAE5MqFpOWERR6EPvN9hhnG5SH0BkNqHkLmNAjdpIZmuJxBo5I1XvUVmsNltdntOuwGIR4N40DC-IV4cEhJsZnIdFIXot+BodDMRIYNCIWg0NPy2cC7LgKZdxjx+N8xDodJEaiyEJJpBI9DoNDsRE8GdJLNYuhhDmBSKK4ddgu8yiIGUz5AqLQlvr9-oCBELQe4wCaqWaQuzwnLMcswjjNhRtvjXXruhAWF6rhNENM2vKYljg+tQ+H8VYrEA */
   id: "ui",
@@ -43,4 +44,4 @@ const uiMachine = createMachine({
 
 const uiActor = createActor(uiMachine);
 
-export { uiActor, uiMachine };
+export { uiActor };


### PR DESCRIPTION
* Refactor `App` component: add **uiActor** init, move logic & child components to `Layout` (src/renderer/App.tsx);
* Refactor `Header`: remove unused states (src/renderer/App.tsx);
* Update `CreateProxy`: implement **uiActor** (src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx);
* Create `Layout` for wrapping all child app components (src/renderer/components/layout/Layout.tsx, src/renderer/components/layout/index.ts);
* Update `dialog `: extract **DialogClose** form **DialogPortal** (src/renderer/components/ui/dialog.tsx);
* Update `ui` FSM export (src/xstate/ui.ts).