### PR TITLE
Implement `uiActor` for `EditProxy` dialog; Add Context for `ui` FSM

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,19 @@ const App = () => {
     uiActor.start();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        uiActor.send({ type: "list" });
+      }
+    };
+    window.addEventListener("keydown", handleEsc);
+
+    return () => {
+      window.removeEventListener("keydown", handleEsc);
+    };
+  }, []);
+
   return <Layout />;
 };
 

--- a/src/renderer/components/common/Header/Header.tsx
+++ b/src/renderer/components/common/Header/Header.tsx
@@ -1,20 +1,10 @@
 import { uiActor } from "@/xstate";
 import { useSelector } from "@xstate/react";
-import { FC, SetStateAction, Dispatch } from "react";
+import { FC } from "react";
 import { Button, Dialog } from "@/renderer/components/ui/";
 import { CreateProxy, EditProxy } from "@/renderer/components/dialogs";
 
-interface IHeaderProps {
-  editProxyDialogOpen: boolean;
-  setEditProxyDialogOpen: Dispatch<SetStateAction<boolean>>;
-  selectedForEditProxy: string | null;
-}
-
-const Header: FC<IHeaderProps> = ({
-  editProxyDialogOpen,
-  setEditProxyDialogOpen,
-  selectedForEditProxy,
-}) => {
+const Header: FC = () => {
   const state = useSelector(uiActor, (state) => state);
   console.log(state);
 
@@ -33,11 +23,8 @@ const Header: FC<IHeaderProps> = ({
         </Button>
         <CreateProxy />
       </Dialog>
-      <Dialog open={editProxyDialogOpen} onOpenChange={setEditProxyDialogOpen}>
-        <EditProxy
-          selectedForEditProxy={selectedForEditProxy}
-          setOpen={setEditProxyDialogOpen}
-        />
+      <Dialog open={state.matches("edit")}>
+        <EditProxy />
       </Dialog>
     </header>
   );

--- a/src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx
+++ b/src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx
@@ -9,12 +9,9 @@ import {
 import { ProxyForm } from "@/renderer/components/templates";
 import { uiActor } from "@/xstate";
 
-const proxyCreateResolver = zodResolver(proxyCreateSchema);
+const proxyResolver = zodResolver(proxyCreateSchema);
 
 const CreateProxy: FC = () => {
-  /**
-   * TODO: rename functions (remove `Create`)
-   */
   const {
     reset: proxyCreateReset,
     clearErrors: proxyCreateClearErrors,
@@ -24,7 +21,7 @@ const CreateProxy: FC = () => {
     formState: { errors: proxyCreateErrors },
     setValue: proxySetValue,
   } = useForm<ProxyCreateFormSchema>({
-    resolver: proxyCreateResolver,
+    resolver: proxyResolver,
   });
 
   const watchedAuthentication = useWatch({

--- a/src/renderer/components/layout/Layout.tsx
+++ b/src/renderer/components/layout/Layout.tsx
@@ -1,6 +1,5 @@
 import { Header } from "@/renderer/components/common";
 import { Main } from "@/renderer/components/views";
-import { useEffect, useState } from "react";
 import { uiActor } from "@/xstate";
 import { useSelector } from "@xstate/react";
 
@@ -9,36 +8,14 @@ import { useSelector } from "@xstate/react";
 const Layout = () => {
   const state = useSelector(uiActor, (state) => state);
 
-  const [editProxyDialogOpen, setEditProxyDialogOpen] =
-    useState<boolean>(false);
-
-  const [selectedForEditProxy, setSelectedForEditProxy] = useState<
-    string | null
-  >(null);
-
-  useEffect(() => {
-    if (selectedForEditProxy !== null) {
-      setEditProxyDialogOpen(true);
-    }
-  }, [selectedForEditProxy]);
-
-  useEffect(() => {
-    if (!editProxyDialogOpen) {
-      setSelectedForEditProxy(null);
-    }
-  }, [editProxyDialogOpen]);
-
   return (
     <div className="container py-5 flex flex-col gap-6">
       <div className="p-4 bg-slate-500 rounded-sm">
-        {state.value.toString()}
+        <p>{JSON.stringify(state.value)}</p>
+        <p>{JSON.stringify(state.context)}</p>
       </div>
-      <Header
-        editProxyDialogOpen={editProxyDialogOpen}
-        setEditProxyDialogOpen={setEditProxyDialogOpen}
-        selectedForEditProxy={selectedForEditProxy}
-      />
-      <Main setSelectedForEditProxy={setSelectedForEditProxy} />
+      <Header />
+      <Main />
     </div>
   );
 };

--- a/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
+++ b/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
@@ -1,12 +1,8 @@
 import { IProxy } from "@/types";
-import { useState, FC, SetStateAction, Dispatch } from "react";
+import { useState, FC } from "react";
 import { ProxyCard } from "@/renderer/components/templates";
 
-interface IProxiesListProps {
-  setSelectedForEditProxy: Dispatch<SetStateAction<string | null>>;
-}
-
-const ProxiesList: FC<IProxiesListProps> = ({ setSelectedForEditProxy }) => {
+const ProxiesList: FC = () => {
   const [proxies, setProxies] = useState<Omit<IProxy, "state">[] | []>([]);
   window.electronAPI.proxyList().then((data) => {
     setProxies(data);
@@ -17,11 +13,7 @@ const ProxiesList: FC<IProxiesListProps> = ({ setSelectedForEditProxy }) => {
       {proxies.length > 0 && (
         <div className="flex flex-col gap-3">
           {proxies.map((proxy) => (
-            <ProxyCard
-              key={proxy.id}
-              proxy={proxy}
-              setSelectedForEditProxy={setSelectedForEditProxy}
-            />
+            <ProxyCard key={proxy.id} proxy={proxy} />
           ))}
         </div>
       )}

--- a/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
+++ b/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
@@ -1,14 +1,14 @@
-import { FC, Dispatch, SetStateAction } from "react";
+import { FC } from "react";
 import { Button, Label, Typography } from "@/renderer/components/ui";
 import { IProxy } from "@/types";
 import { X } from "lucide-react";
+import { uiActor } from "@/xstate";
 
 interface IProxyCardProps {
   proxy: Omit<IProxy, "state">;
-  setSelectedForEditProxy: Dispatch<SetStateAction<string | null>>;
 }
 
-const ProxyCard: FC<IProxyCardProps> = ({ proxy, setSelectedForEditProxy }) => {
+const ProxyCard: FC<IProxyCardProps> = ({ proxy }) => {
   const { id, name, description, port } = proxy;
 
   return (
@@ -21,7 +21,7 @@ const ProxyCard: FC<IProxyCardProps> = ({ proxy, setSelectedForEditProxy }) => {
             variant="outline"
             size="sm"
             onClick={() => {
-              setSelectedForEditProxy(id.toString());
+              uiActor.send({ type: "edit", proxyId: id.toString() });
             }}
           >
             Edit

--- a/src/renderer/components/views/Main/Main.tsx
+++ b/src/renderer/components/views/Main/Main.tsx
@@ -1,14 +1,10 @@
-import { FC, SetStateAction, Dispatch } from "react";
+import { FC } from "react";
 import { ProxiesList } from "@/renderer/components/templates";
 
-interface IMainProps {
-  setSelectedForEditProxy: Dispatch<SetStateAction<string>>;
-}
-
-const Main: FC<IMainProps> = ({ setSelectedForEditProxy }) => {
+const Main: FC = () => {
   return (
     <main>
-      <ProxiesList setSelectedForEditProxy={setSelectedForEditProxy} />
+      <ProxiesList />
     </main>
   );
 };

--- a/src/xstate/ui.ts
+++ b/src/xstate/ui.ts
@@ -1,15 +1,23 @@
-import { createMachine, createActor } from "xstate";
+import { assign, createActor, createMachine } from "xstate";
 
 const uiMachine = createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QFcCWA6VEA2YDEEYuALmANoAMAuoqAA4D2sqxqDAdrSAB6IC0AZgAsATnQAmCgICM4gKwAaEAE9E4oQDZ0AgOzSKOgByjZ+kUIC+FpWkw58AYwBOYAIalKNJCEbNWHLl4EQVF0OXFhXUUVRFkKdE0hYyirGwwsXDxIFk8uXxY2Tm8gjSEw6Wk9Qx1o1QRpDXF0HRENarlUkFts4jxsVFhiXO98-yLQIL4k9FakoSilOukxOQppAQpJQwEd3c7bQhJ8fsHh+iYCgOL+SQF0CoFxQ1laxAE5MqFpOWERR6EPvN9hhnG5SH0BkNqHkLmNAjdpIZmuJxBo5I1XvUVmsNltdntOuwGIR4N40DC-IV4cEhJsZnIdFIXot+BodDMRIYNCIWg0NPy2cC7LgKZdxjx+N8xDodJEaiyEJJpBI9DoNDsRE8GdJLNYuhhDmBSKK4ddgu8yiIGUz5AqLQlvr9-oCBELQe4wCaqWaQuzwnLMcswjjNhRtvjXXruhAWF6rhNENM2vKYljg+tQ+H8VYrEA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QFcCWA6VEA2YDEEYuALmANoAMAuoqAA4D2sqxqDAdrSAB6IC0AZgAsATnQAmCgICM4gKwAaEAE9E4oQDZ0AgOzSKOgByjZ+kUIC+FpWkw58AYwBOYAIalKNJCEbNWHLl4EQVF0OXFhXUUVRFkKdE0hYyirGwwsXDxIFk8uXxY2Tm8gjSEw6Wk9Qx1o1QRpDXF0HRENarlUkFtCEnxsVFhiXO98-yLQIL5JAXQKgXFDWVrEATkyoWk5YRF5oTWhAU7bZzdSPH7B4fomAoDi-nFpQ2bxcQ05RuX6sTkKaQEKJJDAIQaCjhhssRzgMhtQ8jcxoF+El0K0kgcako6tIfn8AUDQWDOuwGIR4N40PC-IUkcEhIDUXIdFIllj+BodKiRNUKH8-uIRHJueC7Lgqbdxjx+JsxDodJFMTEEJJpBI9DoNCCRAsmdJLNYuhgemBSOLEfdgqsyoLmTJ5GyEFaEpttrt9ocDccXO4wGaaRaQpzwgqvjiwnjARRgYSPWl0JC-XcJogUW1Fdjcf9I9HCVYrEA */
   id: "ui",
   initial: "idle",
+  context: {
+    proxyId: null as string | null,
+  },
   states: {
     idle: {
       on: {
         delete: "delete",
         create: "create",
-        edit: "edit",
+        edit: {
+          target: "edit",
+          actions: assign({
+            proxyId: ({ event }) => event.proxyId,
+          }),
+        },
       },
     },
 
@@ -35,6 +43,9 @@ const uiMachine = createMachine({
       on: {
         list: {
           target: "idle",
+          actions: assign({
+            proxyId: null,
+          }),
           reenter: true,
         },
       },


### PR DESCRIPTION
* Add event listener  for `ESC` keyboatd button (src/renderer/App.tsx);
* Update `Header`: remove unused props (src/renderer/components/common/Header/Header.tsx);
* Update `CreateProxy`: rename `proxyResolver` (src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx);
* Update `EditProxy`: remove unused state's props (src/renderer/components/dialogs/EditProxy/EditProxy.tsx);
* Update `Layout`: remove unused **useEffect** & **useState** (src/renderer/components/layout/Layout.tsx);
* Update `ProxiesList`: remove unused props (src/renderer/components/templates/ProxiesList/ProxiesList.tsx);
* Update `ProxyCard`: remove unused props (src/renderer/components/templates/ProxyCard/ProxyCard.tsx);
* Update `Main`: remove unused props (src/renderer/components/views/Main/Main.tsx);
* Update `ui` FSM: add **context** (src/xstate/ui.ts).