### PR TITLE
Add `update` transition for proxiesMachine FSM; Fix type issues

### DIFF
--- a/src/core/Ipc/handlers/proxyCreate.ts
+++ b/src/core/Ipc/handlers/proxyCreate.ts
@@ -15,7 +15,7 @@ const proxyCreate = (ipc: Ipc) => async (params: IProxyCreateParams) => {
   logger("lastKey:", lastKey, "typeof lastKey:", typeof lastKey);
 
   const key = lastKey ? (parseInt(lastKey, 10) + 1).toString() : "1";
-  return await ipc.database.proxies.put(key, proxy);
+  return await ipc.database.proxies.put(key, { id: Number(key), ...proxy });
 };
 
 export { proxyCreate };

--- a/src/core/Ipc/handlers/proxyEdit.ts
+++ b/src/core/Ipc/handlers/proxyEdit.ts
@@ -10,7 +10,7 @@ interface IProxyEditParams {
 
 const proxyEdit = (ipc: Ipc) => async (params: IProxyEditParams) => {
   const { id, proxy } = params;
-  return await ipc.database.proxies.put(id, proxy);
+  return await ipc.database.proxies.put(id, { id: Number(id), ...proxy });
 };
 
 export { proxyEdit };

--- a/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
+++ b/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
@@ -11,14 +11,12 @@ const ProxiesList: FC = () => {
 
   logger(proxiesActorState);
 
-  // useEffect(() => {
-  //   if (uiActorStateValue === "idle") {
-  //     // TODO: fromPromise FSM
-
-  //   }
-  // }, [uiActorStateValue]);
-
-  // const [proxies, setProxies] = useState<Omit<IProxy, "state">[] | []>([]);
+  /**
+   * TODO (1): fromPromise FSM for DB actions
+   */
+  /**
+   * TODO (2): sort by ID
+   */
 
   return (
     <div>


### PR DESCRIPTION
* Fix `proxyCreate` IPC handler type issue with return data (src/core/Ipc/handlers/proxyCreate.ts);
* Fix `proxyEdit ` IPC handler type issue with return data (src/core/Ipc/handlers/proxyCreate.ts);
* Update `EditProxy` component: fix rendering when Delete dialog have opened, add ** proxiesActor** transition (src/renderer/components/dialogs/EditProxy/EditProxy.tsx);
* Remove unused code from `ProxiesList` component (src/renderer/components/templates/ProxiesList/ProxiesList.tsx);
* Update `proxiesMachine` FSM: add **update** transition (src/xstate/proxiesMachine.ts).