### PR TITLE
Remove state property from `IProxy` interface

### DIFF
--- a/src/core/Database/Database.ts
+++ b/src/core/Database/Database.ts
@@ -13,12 +13,12 @@ class Database {
       databaseLocationPath,
       {
         valueEncoding: "json",
-      },
+      }
     );
     // Create proxy sublevel database
     this.proxiesDatabase = this.levelDatabase.sublevel<
       string,
-      Omit<IProxy, "id" | "state">
+      Omit<IProxy, "id">
     >("proxies", {
       keyEncoding: "utf8",
       valueEncoding: "json",

--- a/src/core/Database/sublevels/Proxies.ts
+++ b/src/core/Database/sublevels/Proxies.ts
@@ -22,7 +22,7 @@ class Proxies {
     return new Promise((resolve, reject) => {
       this.proxiesDatabase.put(id, proxy, (err) => {
         if (err) reject(err);
-        proxy.id = Number(id);
+        proxy.id = id;
         resolve(proxy);
       });
     });

--- a/src/core/Ipc/handlers/proxyCreate.ts
+++ b/src/core/Ipc/handlers/proxyCreate.ts
@@ -5,7 +5,7 @@ import debug from "debug";
 const logger = debug("ipc:handlers:proxyCreate");
 interface IProxyCreateParams {
   event: IpcMainInvokeEvent;
-  proxy: Omit<IProxy, "id" | "state">;
+  proxy: Omit<IProxy, "id">;
 }
 
 const proxyCreate = (ipc: Ipc) => async (params: IProxyCreateParams) => {
@@ -15,7 +15,7 @@ const proxyCreate = (ipc: Ipc) => async (params: IProxyCreateParams) => {
   logger("lastKey:", lastKey, "typeof lastKey:", typeof lastKey);
 
   const key = lastKey ? (parseInt(lastKey, 10) + 1).toString() : "1";
-  return await ipc.database.proxies.put(key, { id: Number(key), ...proxy });
+  return await ipc.database.proxies.put(key, { id: key, ...proxy });
 };
 
 export { proxyCreate };

--- a/src/core/Ipc/handlers/proxyEdit.ts
+++ b/src/core/Ipc/handlers/proxyEdit.ts
@@ -10,7 +10,7 @@ interface IProxyEditParams {
 
 const proxyEdit = (ipc: Ipc) => async (params: IProxyEditParams) => {
   const { id, proxy } = params;
-  return await ipc.database.proxies.put(id, { id: Number(id), ...proxy });
+  return await ipc.database.proxies.put(id, { id: id, ...proxy });
 };
 
 export { proxyEdit };

--- a/src/core/Ipc/handlers/proxyList.ts
+++ b/src/core/Ipc/handlers/proxyList.ts
@@ -8,13 +8,13 @@ interface IProxyListParams {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const proxyList = (ipc: Ipc) => async (params: IProxyListParams) => {
-  const data: [string, Omit<IProxy, "id" | "state">][] =
+  const data: [string, Omit<IProxy, "id">][] =
     await ipc.database.proxies.getAll();
 
   const proxies = data.map((entity) => {
     const [id, rest] = entity;
-    const proxy: Omit<IProxy, "state"> = {
-      id: parseInt(id, 10),
+    const proxy: IProxy = {
+      id: id,
       ...rest,
     };
     return proxy;

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,20 +1,18 @@
 import { IProxy } from "./types";
 
 export interface IElectronAPI {
-  proxyCreate: (
-    proxy: Omit<IProxy, "id" | "state">
-  ) => Promise<Omit<IProxy, "state">>;
+  proxyCreate: (proxy: Omit<IProxy, "id">) => Promise<IProxy>;
 
   proxyDelete: (id: string) => Promise<string>;
 
   proxyEdit: (
     id: string,
-    proxy: Omit<IProxy, "id" | "state">
-  ) => Promise<Omit<IProxy, "id" | "state">>;
+    proxy: Omit<IProxy, "id">
+  ) => Promise<Omit<IProxy, "id">>;
 
-  proxyGet: (id: string) => Promise<Omit<IProxy, "id" | "state">>;
+  proxyGet: (id: string) => Promise<Omit<IProxy, "id">>;
 
-  proxyList: () => Promise<Omit<IProxy, "state">[]>;
+  proxyList: () => Promise<IProxy[]>;
 }
 
 declare global {

--- a/src/renderer/components/dialogs/EditProxy/EditProxy.tsx
+++ b/src/renderer/components/dialogs/EditProxy/EditProxy.tsx
@@ -121,7 +121,7 @@ const EditProxy: FC = () => {
         uiActor.send({ type: "list" });
         proxiesActor.send({
           type: "update",
-          editedProxy: { id: Number(proxyId), ...proxy },
+          editedProxy: { id: proxyId, ...proxy },
         });
       }
     } catch (error) {

--- a/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
+++ b/src/renderer/components/templates/ProxiesList/ProxiesList.tsx
@@ -27,7 +27,7 @@ const ProxiesList: FC = () => {
             return (
               <ProxyCard
                 key={index}
-                proxy={{ id: Number(id), ...proxySnapshotContext }}
+                proxy={{ id: id, ...proxySnapshotContext }}
               />
             );
           })}

--- a/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
+++ b/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import { uiActor } from "@/xstate";
 
 interface IProxyCardProps {
-  proxy: Omit<IProxy, "state">;
+  proxy: IProxy;
 }
 
 const ProxyCard: FC<IProxyCardProps> = ({ proxy }) => {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -11,5 +11,5 @@ export interface IProxiesDatabase
     ClassicLevel<string, AnyJson>,
     string | Buffer | Uint8Array,
     string,
-    Omit<IProxy, "id" | "state">
+    Omit<IProxy, "id">
   > {}

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
 
-export type State = "active" | "inactive" | "invalid";
-
 export interface IProxy {
-  id: number;
+  id: string;
   name: string;
   description: string;
   port: number;
-  state: State;
   proxy_host: string;
   proxy_port: number;
   // TODO: type guard for authentication

--- a/src/xstate/proxiesMachine.ts
+++ b/src/xstate/proxiesMachine.ts
@@ -16,13 +16,13 @@ const logger = debug("proxiesMachine");
 const proxiesMachine = createMachine({
   types: {} as {
     context: {
-      newProxy: Omit<IProxy, "state"> | null;
+      newProxy: IProxy | null;
       proxies: ActorRefFrom<typeof proxyMachine>[];
     };
     events:
       | {
           type: "add";
-          newProxy: Omit<IProxy, "state">;
+          newProxy: IProxy;
         }
       | {
           type: "remove";
@@ -30,7 +30,7 @@ const proxiesMachine = createMachine({
         }
       | {
           type: "update";
-          editedProxy: Omit<IProxy, "state">;
+          editedProxy: IProxy;
         };
   },
   id: "friends",

--- a/src/xstate/proxyMachine.ts
+++ b/src/xstate/proxyMachine.ts
@@ -1,4 +1,5 @@
 import { setup } from "xstate";
+import { IProxy } from "@/types";
 
 const proxyMachine = setup({
   types: {
@@ -7,32 +8,8 @@ const proxyMachine = setup({
       | { type: "deactivate" }
       | { type: "invalidate" }
       | { type: "reactivate" },
-    context: {} as {
-      id: string;
-      name: string;
-      description: string;
-      port: number;
-      proxy_host: string;
-      proxy_port: number;
-      authentication: {
-        authentication?: boolean;
-        username?: string;
-        password?: string;
-      };
-    },
-    input: {} as {
-      id: string;
-      name: string;
-      description: string;
-      port: number;
-      proxy_host: string;
-      proxy_port: number;
-      authentication: {
-        authentication?: boolean;
-        username?: string;
-        password?: string;
-      };
-    },
+    context: {} as IProxy,
+    input: {} as IProxy,
   },
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QAcBOB7AHgTwHQEkA7AQwGMAXASwDcwBiMq648sAbQAYBdRFdWSlXSFeITIgAcHCbgBsHAIwBWAOwcVCgMzalAGhDZEAJgCcHXBKVLNClZoAslhSdmaAvm-1oseAIIUaeggwRhoWdm5RZH5BSmFRcQQFaVlcDiM7e00VPQNEawU5FRM1Iw4le0V7FQ8vDBxcfyZ6SkJmABtKCHDOHiQQaIEhEX7E5JNNCyMJBSNcwwQZ3CUOVYV7K0r12Qlagfq8Ig6uulQQgOZWXqiY4YTEZUnNIyMNzWly+yNn-QXZWXsy1MNi+KgkmlkEz23gaR2InQgdGCoUuET6fCGcRGoESSlkKlwmhMFWKakUtl+xjMFisNkyThc7j2hHQwXg-RhCwxsXio0QAFpZJSEPylLgTBKJaoONUNtITNCDgQSBcwDdMbycYh5OY8ao8c8FJY5sKKoD1LJgfIlGZVIqfI1VeqedixA9vgTVmDZvNjBDcHMbETNlUap59g64QjnXc+QgvsLkkYA0ZZKo1BUqjsPB4gA */


### PR DESCRIPTION
* Update type of **proxiesDatabase** instance of `Database` (src/core/Database/Database.ts);
* Update type of `id` in **Proxies** sublevel class (src/core/Database/sublevels/Proxies.ts);
* Update `IProxyCreateParams` & `id` type (src/core/Ipc/handlers/proxyCreate.ts);
* Update `id` type (src/core/Ipc/handlers/proxyEdit.ts);
* Update `id` type & remove `state` (src/core/Ipc/handlers/proxyList.ts);
* Remove `state` (src/interface.d.ts);
* Update `id` type (src/renderer/components/dialogs/EditProxy/EditProxy.tsx);
* Update `id` type (src/renderer/components/templates/ProxiesList/ProxiesList.tsx);
* Remove `state` (src/renderer/components/templates/ProxyCard/ProxyCard.tsx);
* Update `AbstractSublevel` interface (src/types/database.ts);
* Change `id` type; remove `State` type (src/types/proxy.ts);
* Remove `state` (src/xstate/proxiesMachine.ts);
* Update `proxyMachine` types (src/xstate/proxyMachine.ts).