### PR TITLE
Fix Select for `proxy_protocol` reset

### DIFF
--- a/src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx
+++ b/src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx
@@ -3,6 +3,7 @@ import { useEffect, FC } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  Protocol,
   proxySchema as proxyCreateSchema,
   ProxyFormSchema as ProxyCreateFormSchema,
 } from "@/types";
@@ -80,7 +81,7 @@ const CreateProxy: FC = () => {
         name: name,
         description: description,
         port: port as number,
-        proxy_protocol: proxy_protocol,
+        proxy_protocol: proxy_protocol as Protocol,
         proxy_host: proxy_host,
         proxy_port: proxy_port as number,
         authentication: authentication,
@@ -96,6 +97,7 @@ const CreateProxy: FC = () => {
         port: "",
         proxy_host: "",
         proxy_port: "",
+        proxy_protocol: "",
         authentication: {
           authentication: false,
           username: "",

--- a/src/renderer/components/dialogs/EditProxy/EditProxy.tsx
+++ b/src/renderer/components/dialogs/EditProxy/EditProxy.tsx
@@ -2,7 +2,7 @@ import { DialogContent, DialogClose } from "@/renderer/components/ui";
 import { useEffect, FC } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { proxySchema, ProxyFormSchema, isKey } from "@/types";
+import { Protocol, proxySchema, ProxyFormSchema, isKey } from "@/types";
 import { ProxyForm } from "@/renderer/components/templates";
 import { uiActor, proxiesActor } from "@/xstate";
 import { useSelector } from "@xstate/react";
@@ -127,7 +127,7 @@ const EditProxy: FC = () => {
         name: name,
         description: description,
         port: port as number,
-        proxy_protocol: proxy_protocol,
+        proxy_protocol: proxy_protocol as Protocol,
         proxy_host: proxy_host,
         proxy_port: proxy_port as number,
         authentication: authentication,
@@ -136,7 +136,19 @@ const EditProxy: FC = () => {
       };
       const response = await window.electronAPI.proxyEdit(proxyId, proxy);
       // console.log(response);
-      proxyEditReset();
+      proxyEditReset({
+        name: "",
+        description: "",
+        port: "",
+        proxy_host: "",
+        proxy_port: "",
+        proxy_protocol: "",
+        authentication: {
+          authentication: false,
+          username: "",
+          password: "",
+        },
+      });
       if (response) {
         // TODO: communication between actors
         uiActor.send({ type: "list" });

--- a/src/renderer/components/templates/ProxyForm/ProxyForm.tsx
+++ b/src/renderer/components/templates/ProxyForm/ProxyForm.tsx
@@ -169,7 +169,7 @@ const ProxyForm: FC<IProxyFormProps> = ({
             <Controller
               name="proxy_protocol"
               control={proxyControl}
-              defaultValue={undefined}
+              defaultValue={""}
               render={({ field: { onChange, value, name } }) => (
                 <Select onValueChange={onChange} value={value} name={name}>
                   <SelectTrigger

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -80,13 +80,28 @@ export const proxySchema = z.object({
         path: [""],
       }
     ),
-  proxy_protocol: z.enum(PROTOCOLS, {
-    // TODO: unknown error
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    errorMap: (issue, ctx) => {
-      return { message: "Protocol field is required" };
-    },
-  }),
+  proxy_protocol: z
+    .union([
+      z.enum(PROTOCOLS, {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        errorMap: (issue, ctx) => {
+          return { message: "Protocol field is required" };
+        },
+      }),
+      z.literal(""),
+    ])
+    .refine(
+      (proxy_protocol) => {
+        if (proxy_protocol === "") {
+          return false;
+        }
+        return true;
+      },
+      {
+        message: "Port field is required",
+        path: [""],
+      }
+    ),
   proxy_host: z.string().min(4, { message: "Host field is required" }),
   proxy_port: z
     .union([


### PR DESCRIPTION
* Set type for `proxy_protocol` (src/renderer/components/dialogs/CreateProxy/CreateProxy.tsx, src/renderer/components/dialogs/EditProxy/EditProxy.tsx);
* Update `EditProxy` **proxyEditReset** hook (src/renderer/components/dialogs/EditProxy/EditProxy.tsx);
* Update `ProxyForm` proxy_protocol **defaultValue** (src/renderer/components/templates/ProxyForm/ProxyForm.tsx);
* Update `proxySchema`: add zod uniun & refine for **proxy_protocol** (src/types/proxy.ts).