### PR TITLE
Add `proxyStart` handler in IPC, Core & Electron infrastructure

### DIFF
--- a/src/core/Chain/Chain.ts
+++ b/src/core/Chain/Chain.ts
@@ -2,7 +2,7 @@ import ProxyChain, { Server } from "proxy-chain";
 import { IProxy } from "@/types";
 
 class Chain {
-  private proxies: Server[];
+  private proxies: Server[] = [];
 
   public start(proxy: IProxy) {
     const {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -1,16 +1,18 @@
 import path from "path";
-import { Ipc, Database } from "@/core";
+import { Ipc, Database, Chain } from "@/core";
 import { app, ipcMain } from "electron";
 
 class Core {
+  private chain: Chain;
   private databse: Database;
   private ipc: Ipc;
   private databaseLocationPath: string;
 
   constructor() {
+    this.chain = new Chain();
     this.databaseLocationPath = path.join(app.getPath("userData"), "db");
     this.databse = new Database(this.databaseLocationPath);
-    this.ipc = new Ipc(this.databse);
+    this.ipc = new Ipc(this.databse, this.chain);
   }
 
   public start() {
@@ -42,6 +44,12 @@ class Core {
     ipcMain.handle("proxy:list", (event) => {
       return this.ipc.proxyList({
         event: event,
+      });
+    });
+    ipcMain.handle("proxy:start", (event, ...args) => {
+      return this.ipc.proxyStart({
+        event: event,
+        proxy: args[0],
       });
     });
   }

--- a/src/core/Ipc/Ipc.ts
+++ b/src/core/Ipc/Ipc.ts
@@ -1,11 +1,11 @@
-import type { Database as IDatabase } from "@/core";
-import type { Chain as IChain } from "@/core";
+import type { Database as IDatabase, Chain as IChain } from "@/core";
 import {
   proxyCreate,
   proxyDelete,
   proxyEdit,
   proxyGet,
   proxyList,
+  proxyStart,
 } from "./handlers";
 
 class Ipc {
@@ -22,6 +22,7 @@ class Ipc {
   public proxyEdit = proxyEdit(this);
   public proxyGet = proxyGet(this);
   public proxyList = proxyList(this);
+  public proxyStart = proxyStart(this);
 }
 
 export default Ipc;

--- a/src/core/Ipc/handlers/index.ts
+++ b/src/core/Ipc/handlers/index.ts
@@ -3,3 +3,4 @@ export * from "./proxyDelete";
 export * from "./proxyEdit";
 export * from "./proxyGet";
 export * from "./proxyList";
+export * from "./proxyStart";

--- a/src/core/Ipc/handlers/proxyStart.ts
+++ b/src/core/Ipc/handlers/proxyStart.ts
@@ -4,11 +4,11 @@ import { IpcMainInvokeEvent } from "electron";
 
 interface IProxyEditParams {
   event: IpcMainInvokeEvent;
-  id: string;
   proxy: IProxy;
 }
 
 const proxyStart = (ipc: Ipc) => async (params: IProxyEditParams) => {
+  console.log("proxyStart", params);
   const { proxy } = params;
   return ipc.chain.start(proxy);
 };

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -13,6 +13,7 @@ export interface IElectronAPI {
   proxyGet: (id: string) => Promise<Omit<IProxy, "id">>;
 
   proxyList: () => Promise<IProxy[]>;
+  proxyStart: (proxy: IProxy) => void;
 }
 
 declare global {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -25,4 +25,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
    * proxyList
    */
   proxyList: () => ipcRenderer.invoke("proxy:list"),
+
+  proxyStart: (proxy: IProxy) => ipcRenderer.invoke("proxy:start", proxy),
 });

--- a/src/renderer/components/dialogs/DeleteProxy/DeleteProxy.tsx
+++ b/src/renderer/components/dialogs/DeleteProxy/DeleteProxy.tsx
@@ -14,6 +14,7 @@ const DeleteProxy: FC = () => {
   const proxyId = useSelector(uiActor, (state) => state.context.proxyId);
 
   const handleDeleteProxy = () => {
+    if (!proxyId) return;
     window.electronAPI.proxyDelete(proxyId).then((data) => {
       // intagrate this is xstate as fromPromise
       if (data) uiActor.send({ type: "list" });

--- a/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
+++ b/src/renderer/components/templates/ProxyCard/ProxyCard.tsx
@@ -15,6 +15,12 @@ const ProxyCard: FC<IProxyCardProps> = ({ proxy }) => {
 
   const state = useSelector(proxy, (state) => state.value);
 
+  if (state.match("Active")) {
+    const proxytSnapshot = proxy.getSnapshot().context;
+    console.log(proxytSnapshot);
+    window.electronAPI.proxyStart(proxytSnapshot);
+  }
+
   return (
     <div className="flex flex-col gap-4 p-2 border rounded-md">
       <div className="flex items-center justify-between">


### PR DESCRIPTION
* Fix `Chain` class: set empty array for **proxies** (src/core/Chain/Chain.ts);
* Add **Chain** class & **proxy:start** handler for `Core` (src/core/Core.ts);
* Update `proxyStart` IPC handler (src/core/Ipc/handlers/proxyStart.ts);
* Update `Ipc` class: add **proxyStart** handler (src/core/Ipc/Ipc.ts);
* Extend `interface.d.ts` with **proxyStart** handler (src/interface.d.ts);
* Extend `preload.ts`  with **proxyStart** handler (src/preload.ts);
* Fix `DeleteProxy` dialog: add check for  **proxyId** (src/renderer/components/dialogs/DeleteProxy/DeleteProxy.tsx);
* Update `ProxyCard`: add **proxyStart** handler (src/renderer/components/templates/ProxyCard/ProxyCard.tsx).