### PR TITLE
Create `tabSetBounds` IPC handler; Update `Layout`, `Core` & `Tabs`

### DIFF
--- a/src/browser/components/layout/Layout.tsx
+++ b/src/browser/components/layout/Layout.tsx
@@ -22,7 +22,7 @@ const Layout = () => {
         };
         logger("viewParams:", viewParams);
         // a function defined in the context bridge that sends the dimensions back via IPC
-        window.electronAPI.sendResizeEvent(viewParams);
+        window.electronAPI.tabSetBounds(viewParams);
       }
     };
     // Do this once on init

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -148,10 +148,12 @@ class Core {
         tab: args[0],
       });
     });
-    ipcMain.handle("browser:sendResizeEvent", (event, ...args) => {
-      logger("browser:sendResizeEvent ...args:", args);
-      return this.tabs.setBounds(args[0]);
-      // TODO: add IPC handler
+    ipcMain.handle("browser:tabSetBounds", (event, ...args) => {
+      logger("browser:tabSetBounds ...args:", args);
+      return this.ipc.tabSetBounds({
+        event: event,
+        viewSize: args[0],
+      });
     });
   }
 }

--- a/src/core/Ipc/Ipc.ts
+++ b/src/core/Ipc/Ipc.ts
@@ -19,6 +19,7 @@ import {
   tabClose,
   tabCreate,
   tabGo,
+  tabSetBounds,
 } from "./handlers";
 
 class Ipc {
@@ -55,6 +56,7 @@ class Ipc {
   public tabClose = tabClose(this);
   public tabCreate = tabCreate(this);
   public tabGo = tabGo(this);
+  public tabSetBounds = tabSetBounds(this);
 }
 
 export default Ipc;

--- a/src/core/Ipc/handlers/index.ts
+++ b/src/core/Ipc/handlers/index.ts
@@ -13,3 +13,4 @@ export * from "./serversGetIds";
 export * from "./tabClose";
 export * from "./tabCreate";
 export * from "./tabGo";
+export * from "./tabSetBounds";

--- a/src/core/Ipc/handlers/tabGo.ts
+++ b/src/core/Ipc/handlers/tabGo.ts
@@ -2,7 +2,7 @@ import { Ipc } from "@/core";
 import debug from "debug";
 import { IpcMainInvokeEvent } from "electron";
 import { ITab } from "@/interfaces";
-const logger = debug("ipc:handlers:loadUrl");
+const logger = debug("ipc:handlers:tabGo");
 
 interface ITabGoParams {
   event: IpcMainInvokeEvent;

--- a/src/core/Ipc/handlers/tabSetBounds.ts
+++ b/src/core/Ipc/handlers/tabSetBounds.ts
@@ -1,0 +1,17 @@
+import { Ipc } from "@/core";
+import debug from "debug";
+import { IViewSize } from "@/interfaces";
+import { IpcMainInvokeEvent } from "electron";
+const logger = debug("ipc:handlers:tabSetBounds");
+
+interface ITabSetBoundsParams {
+  event: IpcMainInvokeEvent;
+  viewSize: IViewSize;
+}
+
+const tabSetBounds = (ipc: Ipc) => async (params: ITabSetBoundsParams) => {
+  logger("viewSize", params.viewSize);
+  return ipc.tabs.setBounds(params.viewSize);
+};
+
+export { tabSetBounds };

--- a/src/core/Tabs/Tabs.ts
+++ b/src/core/Tabs/Tabs.ts
@@ -2,7 +2,7 @@ import { ITab, IViewSize } from "@/interfaces";
 import { WebContentsView, BrowserWindow } from "electron";
 import debug from "debug";
 
-const logger = debug("core:Views");
+const logger = debug("core:Tabs");
 
 interface IView extends ITab {
   view: WebContentsView;
@@ -15,6 +15,7 @@ interface IView extends ITab {
 class Views {
   private views: Record<number, IView>;
   private browserWindow: BrowserWindow;
+  private bounds: IViewSize;
 
   constructor() {
     this.views = {};
@@ -31,8 +32,8 @@ class Views {
 
     view.webContents.loadURL(url);
 
-    // view.setBounds(this.bowserWindow.getBounds());
-    view.setBounds({ x: 200, y: 200, width: 400, height: 400 });
+    const { topOffset, width, height } = this.bounds;
+    view.setBounds({ x: 0, y: topOffset, width: width, height: height });
 
     this.browserWindow.contentView.addChildView(view);
   }
@@ -63,6 +64,7 @@ class Views {
   }
 
   public async setBounds(viewSize: IViewSize) {
+    this.bounds = viewSize;
     const { topOffset, width, height } = viewSize;
     Object.keys(this.views).forEach((key) => {
       const id = Number(key);

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -42,5 +42,5 @@ export interface IElectronAPI {
 
   tabGo: (tab: ITab) => void;
 
-  sendResizeEvent: (viewSize: IViewSize) => void;
+  tabSetBounds: (viewSize: IViewSize) => void;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -92,8 +92,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
    */
   tabGo: (tab: ITab) => ipcRenderer.invoke("browser:tabGo", tab),
   /**
-   * sendResizeEvent
+   * tabSetBounds
    */
-  sendResizeEvent: (viewSize: IViewSize) =>
-    ipcRenderer.invoke("browser:sendResizeEvent", viewSize),
+  tabSetBounds: (viewSize: IViewSize) =>
+    ipcRenderer.invoke("browser:tabSetBounds", viewSize),
 });


### PR DESCRIPTION
* Update `Layout`: rename **sendResizeEvent** to ** tabSetBounds** _electronAPI_ handler (src/browser/components/layout/Layout.tsx);
* Update `Core`: refactor **browser:sendResizeEvent** listener to **browser:tabSetBounds** with IPC **tabSetBounds** method (src/core/Core.ts);
* Create `tabSetBounds` IPC handler (src/core/Ipc/handlers/tabSetBounds.ts, src/core/Ipc/handlers/index.ts);
* Fix `tabGo` IPC handler: fix logger prefix (src/core/Ipc/handlers/tabGo.ts);
* Update `Ipc`: add **tabSetBounds** method (src/core/Ipc/Ipc.ts);
* Update `Tabs`: add **bounds** property; update **setBounds** method (src/core/Tabs/Tabs.ts);
* Update `interface.d.ts` & `preload.ts`: rename **sendResizeEvent** to ** tabSetBounds** (src/preload.ts, src/interface.d.ts).